### PR TITLE
Added 0.0.0.0 to allowed hosts in debug mode

### DIFF
--- a/proj/settings.py
+++ b/proj/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = "django-insecure-$^e#o&rg#c$)114)g!mgn=b_#$8n5hsma2r7xoaf-%-0o^ei4g
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["0.0.0.0"] if DEBUG else []
 
 
 # Application definition


### PR DESCRIPTION
The address 0.0.0.0 should be added to allowed hosts when in debug mode for scanning by automated tooling. Otherwise the following error will surface

**Before Enhancement**

<img width="1040" alt="DisallowedHost" src="https://user-images.githubusercontent.com/38992126/165153262-07035521-49ee-41ef-a52f-18d17cb48be4.png">

**After Enhancement**

<img width="1147" alt="AllowedHost" src="https://user-images.githubusercontent.com/38992126/165153940-3859fa49-b408-47f5-9e6b-78bb70d56998.png">

